### PR TITLE
fix: detach debugger when closing devtools window

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 .eslintrc*.js
 out/
+coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 out/
+coverage/

--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -1,6 +1,6 @@
 import { Box, Stack } from '@mui/material'
 import * as React from 'react'
-import { useEffect, useLayoutEffect, useReducer, useState } from 'react'
+import { useLayoutEffect, useReducer } from 'react'
 
 import * as Requests from './requests'
 

--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -1,6 +1,6 @@
 import { Box, Stack } from '@mui/material'
 import * as React from 'react'
-import { useEffect, useReducer } from 'react'
+import { useEffect, useLayoutEffect, useReducer, useState } from 'react'
 
 import * as Requests from './requests'
 
@@ -10,7 +10,7 @@ const App = () => {
     []
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     Requests.listen()
     const unsubscribe = Requests.subscribe((req) => {
       pushRequest(req)

--- a/src/panel/index.tsx
+++ b/src/panel/index.tsx
@@ -3,8 +3,17 @@ import '@fontsource/roboto/400.css'
 import '@fontsource/roboto/500.css'
 import '@fontsource/roboto/700.css'
 import * as React from 'react'
-import * as ReactDOM from 'react-dom'
+import { render, unmountComponentAtNode } from 'react-dom'
 
 import App from './App'
 
-ReactDOM.render(<App />, document.getElementById('app'))
+const container = document.getElementById('app')
+if (container === null) {
+  throw new Error('could not find #app container element')
+}
+
+render(<App />, container)
+
+window.addEventListener('beforeunload', () => {
+  unmountComponentAtNode(container)
+})


### PR DESCRIPTION
Before the window unloads, use `beforeWindowUnload` event to unmount the app component. Since `unlisten` is called in the `useLayoutEffect` cleanup callback, the debugger will be detached before closing the window, making it possible to reattach when reopening the devtools